### PR TITLE
Updated interface for metta and now uses uuids

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ testing sets.
 - `end_time` (date.dateime): The last time that enters your covariate calculations.
 - `prediction_window` (int): The length of the prediction window you are using in this matrix (in months).
 - `label_name` (str): The outcome variable's column name. This column must be in the last position in your dataframe.
+- `matrix_id` (str): Human readable id for the dataset
 
 ```
 import metta
@@ -27,6 +28,7 @@ train_config = {'start_time': datetime.date(2012, 12, 20),
                 'label_name': 'inspection_1yr',
                 'label_type': 'binary',
                 'prediction_window': 3,
+                'matrix_id': 'CDPH_2012',
                 'feature_names': ['break_last_3yr', 'soil', 'pressure_zone']}
 
 
@@ -36,11 +38,12 @@ test_config = {'start_time': datetime.date(2015, 12, 20),
                'label_name': 'inspection_1yr',
                'label_type': 'binary',
                'prediction_window': 3,
+               'matrix_id': 'CDPH_2015',
                'feature_names': ['break_last_3yr', 'soil', 'pressure_zone']}
 
 
 metta.archive_train_test(train_config, X_train,
-                         'CPDH_train_2012', test_config, X_test, 'CPDH_test_2014',
+                         test_config, X_test,
                          directory='./old_matrices')
 
 ```

--- a/metta/metta_io.py
+++ b/metta/metta_io.py
@@ -8,12 +8,14 @@ import os
 import pandas as pd
 import warnings
 import datetime
+import uuid
+
 
 warnings.filterwarnings("ignore")
 
 
-def archive_train_test(train_config, df_train, title_train,
-                       test_config, df_test, title_test,
+def archive_train_test(train_config, df_train,
+                       test_config, df_test,
                        directory='.', format='hd5'):
     """
     Main function for archiving train and test sets
@@ -44,15 +46,24 @@ def archive_train_test(train_config, df_train, title_train,
     """
 
     abs_path_dir = os.path.abspath(directory)
+    set_uuids = load_uuids(abs_path_dir)
 
     check_config_types(train_config)
     check_config_types(test_config)
 
-    _store_matrix(train_config, df_train, title_train, abs_path_dir)
-    _store_matrix(test_config, df_test, title_test, abs_path_dir)
+    train_uuid = generate_uuid(train_config)
+    test_uuid = generate_uuid(test_config)
+
+    train_config['metta-uuid'] = train_uuid
+    test_config['metta-uuid'] = test_uuid
+
+    if not(train_uuid in set_uuids):
+        _store_matrix(train_config, df_train, train_uuid, abs_path_dir)
+    if not(test_uuid in set_uuids):
+        _store_matrix(test_config, df_test, test_uuid, abs_path_dir)
 
     with open(abs_path_dir + '/' + 'matrix_pairs.txt', 'a') as outfile:
-        outfile.write(','.join([title_train, title_test]) + '\n')
+        outfile.write(','.join([train_uuid, test_uuid]) + '\n')
 
 
 def _store_matrix(metadata, df_data, title, directory, format='hd5'):
@@ -106,8 +117,12 @@ def _store_matrix(metadata, df_data, title, directory, format='hd5'):
         if format == 'hd5':
             hdf = pd.HDFStore(directory + '/' + title + '.h5')
             hdf.put(title, df_data, data_columns=True)
+            hdf.close()
         elif format == 'csv':
             df_data.to_csv(directory + '/' + title + '.csv')
+
+        with open(directory + '/' + '.matrix_uuids', 'a') as uuid_file:
+            uuid_file.write(title + '\n')
 
 
 def check_config_types(dict_config):
@@ -125,6 +140,7 @@ def check_config_types(dict_config):
     - end_time: datetime.datetime
     - prediction_window: int
     - label_name: str
+    - matrix_id: human readable name for the data
 
     Raises
     ------
@@ -133,7 +149,8 @@ def check_config_types(dict_config):
 
     """
     set_required_names = set(
-        ['start_time', 'end_time', 'prediction_window', 'label_name'])
+        ['start_time', 'end_time', 'prediction_window', 'label_name',
+         'data_id'])
 
     if not(set_required_names.issubset(dict_config.keys())):
         raise IOError('missing required keys in dictionary',
@@ -143,3 +160,44 @@ def check_config_types(dict_config):
     assert isinstance(dict_config['start_time'], datetime.date)
     assert isinstance(dict_config['end_time'], datetime.date)
     assert isinstance(dict_config['prediction_window'], int)
+    assert isinstance(dict_config['label'], str)
+
+
+def load_uuids(directory):
+    """
+    Check if uuid already exits.
+
+    Parameters
+    ---------
+    directory: str
+        path to working directory
+
+    Returns
+    -------
+    uuids: set
+       set of uuids. empty set of there is
+       no .matrix_uuids file
+
+    """
+    uuid_fname = directory + '/' + '.matrix_uuids'
+    if os.path.isfile(uuid_fname):
+        with open(uuid_fname, 'r') as uuid_file:
+            uuids = set([str_uuid.strip('\n') for str_uuid in uuid_file])
+        return uuids
+    else:
+        return set([])
+
+
+def generate_uuid(metadata):
+    """ Generate a unique identifier given a dictionary of matrix metadata.
+
+    :param metadata: metadata for the matrix
+    :type metadata: dict
+    :returns: unique name for the file
+    :rtype: str
+    """
+    identifier = ''
+    for key in sorted(metadata.keys()):
+        identifier = '{0}_{1}'.format(identifier, str(metadata[key]))
+    name_uuid = str(uuid.uuid3(uuid.NAMESPACE_DNS, identifier))
+    return name_uuid


### PR DESCRIPTION
Instead of using a user-specified title metta just generates a
uuid based on the values in the config files.

Metta stores all the uuids in .matrix_uuids to check against and
does not write if uuid already exists.

Updated documentation in README.