### PR TITLE
Added Recover Function

### DIFF
--- a/metta/metta_io.py
+++ b/metta/metta_io.py
@@ -234,7 +234,7 @@ def check_config_types(dict_config):
 
 def load_uuids(uuid_fname):
     """
-    Check if uuid already exits.
+    Return a list of existing uuids.
 
     Parameters
     ---------
@@ -270,3 +270,37 @@ def generate_uuid(metadata):
         identifier = '{0}_{1}'.format(identifier, str(metadata[key]))
     name_uuid = str(uuid.uuid3(uuid.NAMESPACE_DNS, identifier))
     return name_uuid
+
+
+def recover_matrix(config, directory='.'):
+    """Recover a matrix by either its config or uuid.
+
+    Parameters
+    ----------
+    config: str or dict
+        config metadata for the matrix or uuid
+    directory: str
+        path to search for the matrix
+
+    Returns
+    -------
+    df_matrix: DataFrame
+        DataFrame of specified matrix
+    None:
+        If no matrix matrix is found
+    """
+
+    if isinstance(config, dict):
+        uuid = generate_uuid(config)
+    else:
+        uuid = config
+
+    uuid_fname = directory + '/' + '.matrix_uuids'
+    set_uuids = load_uuids(uuid_fname)
+
+    if uuid in set_uuids:
+        fname = directory + '/' + uuid + '.h5'
+        df_matrix = pd.read_hdf(fname)
+        return df_matrix
+    else:
+        return None

--- a/metta/tests/test_metta_io.py
+++ b/metta/tests/test_metta_io.py
@@ -131,3 +131,21 @@ class TestMettaIO(unittest.TestCase):
             self.temp_file('55c1c5ab-1325-3c80-a79b-aaa23e37bb82.yaml')
         )
         assert len(os.listdir(self.temp_dir)) == 4
+
+    def test_recover(self):
+        df_data = pd.read_csv(example_data_csv)
+        fake_uuid = '55c1c5ab-1325-3c80-a79b-aaa23e37bb82'
+        metta.metta_io.archive_train_test(dict_test_config, df_data,
+                                          dict_test_config, df_data,
+                                          directory=self.temp_dir)
+
+        assert metta.metta_io.recover_matrix(
+            'garbageuuid', directory=self.temp_dir) is None
+
+        df_uuid = metta.metta_io.recover_matrix(dict_test_config,
+                                                directory=self.temp_dir)
+        assert df_data.equals(df_uuid)
+
+        df_config = metta.metta_io.recover_matrix(fake_uuid,
+                                                  directory=self.temp_dir)
+        assert df_data.equals(df_config)


### PR DESCRIPTION
The function metta.metta_io.recover_matrix will recover
a matrix if it already exists given the uuid or config
and path to a directory.

closes #18 